### PR TITLE
Add optional SQLite-backed Playwright test results persistence layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ BASE_URL=https://playground.testduo.co.za
 # (Leave blank if you want to run only public tests)
 E2E_EMAIL=
 E2E_PASSWORD=
+
+# Optional: persist run/test results to SQLite for analytics/dashboarding
+RESULTS_DB_ENABLED=false
+RESULTS_DB_PATH=./artifacts/results.db

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,10 @@
 import { defineConfig, devices } from "@playwright/test";
 import { env } from "./src/utils/env";
 
+const dbReporter: [string, { dbPath: string; enabled: boolean }][] = env.RESULTS_DB_ENABLED
+  ? [["./src/reporting/ResultsDbReporter.ts", { dbPath: env.RESULTS_DB_PATH, enabled: true }]]
+  : [];
+
 export default defineConfig({
   testDir: "./tests",
   timeout: 30_000,
@@ -24,7 +28,8 @@ export default defineConfig({
 
   reporter: [
     ["list"],
-    ["html", { open: "never", outputFolder: "playwright-report" }]
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+    ...dbReporter,
   ],
 
   use: {

--- a/readme.md
+++ b/readme.md
@@ -418,3 +418,62 @@ When adding a new flow, follow this order:
 - Playwright `storageState` reuse for fast authenticated suites.
 - Visual regression assertions and baseline lifecycle.
 - CI strategy (parallelization, retries, artifact triage).
+
+---
+
+## Database-backed Test Results (SQLite)
+
+A new optional Playwright reporter now persists execution metadata to SQLite so you can build dashboards, trend analytics, flaky-test detection, and prediction/risk layers on top of historical runs.
+
+### What was added
+
+- **Custom reporter**: `src/reporting/ResultsDbReporter.ts`
+  - Writes one `test_runs` row per run.
+  - Writes one `test_results` row per finalized test case.
+  - Writes `test_artifacts` rows for saved attachments (screenshots, traces, etc).
+  - Captures error message and stack trace for failed tests when available.
+- **Schema/init layer**: `src/reporting/db/schema.ts` + `src/reporting/db/resultsDb.ts`
+  - Creates the database automatically on first run.
+  - Uses indexed tables designed to be straightforward to port to PostgreSQL.
+- **Starter dashboard query helpers**: `src/reporting/queries/dashboardQueries.ts`
+  - Recent runs
+  - Failure rate by test
+  - Flaky candidate tests
+  - Slowest tests
+  - Failures by module
+
+### Enable it
+
+Add to `.env`:
+
+```bash
+RESULTS_DB_ENABLED=true
+RESULTS_DB_PATH=./artifacts/results.db
+```
+
+Then run tests as normal:
+
+```bash
+npm test
+```
+
+### SQLite database location
+
+By default, the DB is written to:
+
+```bash
+./artifacts/results.db
+```
+
+You can override it with `RESULTS_DB_PATH`.
+
+### Why this helps future analytics/dashboard work
+
+The schema stores run-level, test-level, and artifact-level data with stable test keys and metadata (branch, commit SHA, project/browser, module/page hints), giving you a clean base for:
+
+- run trend reporting
+- flaky detection heuristics
+- module/page risk hotspots
+- future prediction or risk scoring models
+
+The DB access logic is isolated behind a small repository layer so a PostgreSQL adapter can be introduced later with minimal disruption to reporter logic.

--- a/src/reporting/ResultsDbReporter.ts
+++ b/src/reporting/ResultsDbReporter.ts
@@ -1,0 +1,224 @@
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestError,
+  TestResult,
+} from "@playwright/test/reporter";
+import { ResultsDb } from "./db/resultsDb";
+
+type ReporterOptions = {
+  enabled?: boolean;
+  dbPath?: string;
+  environment?: string;
+  triggeredBy?: string;
+};
+
+type FinalizedTestResult = {
+  test: TestCase;
+  result: TestResult;
+};
+
+function asIsoDate(value: Date): string {
+  return value.toISOString();
+}
+
+function getFailureType(result: TestResult): string | undefined {
+  if (!result.error) {
+    return undefined;
+  }
+
+  if (result.status === "timedOut") {
+    return "timeout";
+  }
+
+  if (result.error.message?.toLowerCase().includes("expect(")) {
+    return "assertion";
+  }
+
+  return "runtime";
+}
+
+function resolveBrowserName(projectName: string | undefined): string | undefined {
+  if (!projectName) {
+    return undefined;
+  }
+
+  const knownBrowsers = ["chromium", "firefox", "webkit"];
+  return knownBrowsers.find((browser) => projectName.includes(browser));
+}
+
+function getModuleAndPage(filePath: string | undefined): { moduleName?: string; pageName?: string } {
+  if (!filePath) {
+    return {};
+  }
+
+  const normalized = filePath.replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  const testsIndex = parts.indexOf("tests");
+  const fromTests = testsIndex >= 0 ? parts.slice(testsIndex + 1) : parts;
+
+  const fileName = fromTests[fromTests.length - 1] ?? "";
+  const pageName = fileName
+    .replace(/\.spec\.ts$/, "")
+    .replace(/\.setup\.ts$/, "")
+    .replace(/\.ts$/, "") || undefined;
+
+  const moduleName = fromTests.length > 1 ? fromTests[0] : undefined;
+
+  return { moduleName, pageName };
+}
+
+class ResultsDbReporter implements Reporter {
+  private readonly enabled: boolean;
+  private readonly dbPath: string;
+  private readonly environment: string;
+  private readonly triggeredBy: string;
+  private readonly runUuid: string;
+  private readonly startedAt: Date;
+
+  private db: ResultsDb | null = null;
+  private runId: number | null = null;
+  private finalizedResults = new Map<string, FinalizedTestResult>();
+
+  constructor(options: ReporterOptions = {}) {
+    this.enabled = options.enabled ?? process.env.RESULTS_DB_ENABLED === "true";
+    this.dbPath = options.dbPath ?? process.env.RESULTS_DB_PATH ?? "./artifacts/results.db";
+    this.environment = options.environment ?? process.env.TEST_ENV ?? process.env.NODE_ENV ?? "local";
+    this.triggeredBy = options.triggeredBy ?? process.env.GITHUB_ACTOR ?? process.env.USER ?? "local";
+
+    this.runUuid = randomUUID();
+    this.startedAt = new Date();
+  }
+
+  onBegin(config: FullConfig, suite: Suite): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.db = new ResultsDb(this.dbPath);
+
+    const totalTests = suite.allTests().length;
+    const branch = process.env.GIT_BRANCH ?? process.env.BRANCH_NAME;
+    const commitSha = process.env.GIT_COMMIT ?? process.env.GITHUB_SHA;
+    const buildNumber = process.env.BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER;
+
+    const projectNames = config.projects.map((project) => project.name).join(", ");
+    this.runId = this.db.insertTestRun({
+      runUuid: this.runUuid,
+      startedAt: asIsoDate(this.startedAt),
+      status: "running",
+      totalTests,
+      passedCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+      branch,
+      commitSha,
+      buildNumber,
+      environment: this.environment,
+      browser: projectNames,
+      triggeredBy: this.triggeredBy,
+    });
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    if (!this.enabled || !this.db || !this.runId) {
+      return;
+    }
+
+    this.finalizedResults.set(test.id, { test, result });
+  }
+
+  onEnd(result: FullResult): void {
+    if (!this.enabled || !this.db || !this.runId) {
+      return;
+    }
+
+    let passedCount = 0;
+    let failedCount = 0;
+    let skippedCount = 0;
+
+    for (const { test, result: testResult } of this.finalizedResults.values()) {
+      const status = testResult.status;
+      if (status === "passed") {
+        passedCount += 1;
+      } else if (status === "skipped") {
+        skippedCount += 1;
+      } else {
+        failedCount += 1;
+      }
+
+      const titlePath = test.titlePath();
+      const suiteName = titlePath.slice(1, -1).join(" > ") || undefined;
+      const stableTestKey = `${test.location.file}::${titlePath.join(" > ")}`;
+
+      const browser = resolveBrowserName(test.parent.project()?.name);
+      const filePath = path.relative(process.cwd(), test.location.file);
+      const { moduleName, pageName } = getModuleAndPage(filePath);
+
+      this.db.insertResultWithArtifacts(
+        {
+          testRunId: this.runId,
+          stableTestKey,
+          testTitle: test.title,
+          suiteName,
+          filePath,
+          projectName: test.parent.project()?.name,
+          browser,
+          status,
+          retry: testResult.retry,
+          durationMs: testResult.duration,
+          errorMessage: testResult.error?.message,
+          stackTrace: testResult.error?.stack,
+          failureType: getFailureType(testResult),
+          moduleName,
+          pageName,
+        },
+        testResult.attachments
+          .filter((attachment) => attachment.path)
+          .map((attachment) => ({
+            artifactType: attachment.contentType ?? attachment.name,
+            artifactPath: attachment.path as string,
+          })),
+      );
+    }
+
+    const finishedAt = new Date();
+    this.db.updateTestRunByUuid(this.runUuid, {
+      finishedAt: asIsoDate(finishedAt),
+      status: result.status,
+      totalTests: this.finalizedResults.size,
+      passedCount,
+      failedCount,
+      skippedCount,
+      durationMs: finishedAt.getTime() - this.startedAt.getTime(),
+    });
+
+    this.db.close();
+  }
+
+  onError(error: TestError): void {
+    if (!this.enabled || !this.db || !this.runId) {
+      return;
+    }
+
+    const now = new Date();
+    this.db.updateTestRunByUuid(this.runUuid, {
+      finishedAt: asIsoDate(now),
+      status: "failed",
+      totalTests: this.finalizedResults.size,
+      passedCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+      durationMs: now.getTime() - this.startedAt.getTime(),
+    });
+
+    console.error(`[results-db-reporter] ${error.message}`);
+  }
+}
+
+export default ResultsDbReporter;

--- a/src/reporting/db/resultsDb.ts
+++ b/src/reporting/db/resultsDb.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { SCHEMA_SQL } from "./schema";
+
+export type TestRunInsert = {
+  runUuid: string;
+  startedAt: string;
+  status: string;
+  totalTests: number;
+  passedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  durationMs?: number;
+  branch?: string;
+  commitSha?: string;
+  buildNumber?: string;
+  environment?: string;
+  browser?: string;
+  triggeredBy?: string;
+};
+
+export type TestRunUpdate = {
+  finishedAt: string;
+  status: string;
+  totalTests: number;
+  passedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  durationMs: number;
+  browser?: string;
+};
+
+export type TestResultInsert = {
+  testRunId: number;
+  stableTestKey: string;
+  testTitle: string;
+  suiteName?: string;
+  filePath?: string;
+  projectName?: string;
+  browser?: string;
+  status: string;
+  retry: number;
+  durationMs?: number;
+  errorMessage?: string;
+  stackTrace?: string;
+  failureType?: string;
+  moduleName?: string;
+  pageName?: string;
+};
+
+export type TestArtifactInsert = {
+  testResultId: number;
+  artifactType: string;
+  artifactPath: string;
+};
+
+export class ResultsDb {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    const resolvedPath = path.resolve(dbPath);
+    fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+    this.db = new DatabaseSync(resolvedPath);
+    this.db.exec("PRAGMA journal_mode = WAL;");
+    this.db.exec("PRAGMA foreign_keys = ON;");
+    this.db.exec(SCHEMA_SQL);
+  }
+
+  insertTestRun(data: TestRunInsert): number {
+    const stmt = this.db.prepare(`
+      INSERT INTO test_runs (
+        run_uuid, started_at, status, total_tests, passed_count, failed_count, skipped_count,
+        duration_ms, branch, commit_sha, build_number, environment, browser, triggered_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      data.runUuid,
+      data.startedAt,
+      data.status,
+      data.totalTests,
+      data.passedCount,
+      data.failedCount,
+      data.skippedCount,
+      data.durationMs ?? null,
+      data.branch ?? null,
+      data.commitSha ?? null,
+      data.buildNumber ?? null,
+      data.environment ?? null,
+      data.browser ?? null,
+      data.triggeredBy ?? null,
+    );
+
+    return Number(result.lastInsertRowid);
+  }
+
+  updateTestRunByUuid(runUuid: string, data: TestRunUpdate): void {
+    const stmt = this.db.prepare(`
+      UPDATE test_runs
+      SET
+        finished_at = ?,
+        status = ?,
+        total_tests = ?,
+        passed_count = ?,
+        failed_count = ?,
+        skipped_count = ?,
+        duration_ms = ?,
+        browser = COALESCE(?, browser)
+      WHERE run_uuid = ?
+    `);
+
+    stmt.run(
+      data.finishedAt,
+      data.status,
+      data.totalTests,
+      data.passedCount,
+      data.failedCount,
+      data.skippedCount,
+      data.durationMs,
+      data.browser ?? null,
+      runUuid,
+    );
+  }
+
+  insertTestResult(data: TestResultInsert): number {
+    const stmt = this.db.prepare(`
+      INSERT INTO test_results (
+        test_run_id, stable_test_key, test_title, suite_name, file_path, project_name,
+        browser, status, retry, duration_ms, error_message, stack_trace,
+        failure_type, module_name, page_name
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      data.testRunId,
+      data.stableTestKey,
+      data.testTitle,
+      data.suiteName ?? null,
+      data.filePath ?? null,
+      data.projectName ?? null,
+      data.browser ?? null,
+      data.status,
+      data.retry,
+      data.durationMs ?? null,
+      data.errorMessage ?? null,
+      data.stackTrace ?? null,
+      data.failureType ?? null,
+      data.moduleName ?? null,
+      data.pageName ?? null,
+    );
+
+    return Number(result.lastInsertRowid);
+  }
+
+  insertTestArtifact(data: TestArtifactInsert): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO test_artifacts (test_result_id, artifact_type, artifact_path)
+      VALUES (?, ?, ?)
+    `);
+
+    stmt.run(data.testResultId, data.artifactType, data.artifactPath);
+  }
+
+  insertResultWithArtifacts(result: TestResultInsert, artifacts: Omit<TestArtifactInsert, "testResultId">[]): number {
+    this.db.exec("BEGIN");
+    try {
+      const testResultId = this.insertTestResult(result);
+      for (const artifact of artifacts) {
+        this.insertTestArtifact({
+          testResultId,
+          artifactType: artifact.artifactType,
+          artifactPath: artifact.artifactPath,
+        });
+      }
+      this.db.exec("COMMIT");
+      return testResultId;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/src/reporting/db/schema.ts
+++ b/src/reporting/db/schema.ts
@@ -1,0 +1,74 @@
+export const SCHEMA_SQL = `
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS test_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_uuid TEXT NOT NULL UNIQUE,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  status TEXT NOT NULL,
+  total_tests INTEGER NOT NULL DEFAULT 0,
+  passed_count INTEGER NOT NULL DEFAULT 0,
+  failed_count INTEGER NOT NULL DEFAULT 0,
+  skipped_count INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER,
+  branch TEXT,
+  commit_sha TEXT,
+  build_number TEXT,
+  environment TEXT,
+  browser TEXT,
+  triggered_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_test_runs_started_at ON test_runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_test_runs_status ON test_runs(status);
+CREATE INDEX IF NOT EXISTS idx_test_runs_branch ON test_runs(branch);
+
+CREATE TABLE IF NOT EXISTS test_results (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  test_run_id INTEGER NOT NULL,
+  stable_test_key TEXT NOT NULL,
+  test_title TEXT NOT NULL,
+  suite_name TEXT,
+  file_path TEXT,
+  project_name TEXT,
+  browser TEXT,
+  status TEXT NOT NULL,
+  retry INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER,
+  error_message TEXT,
+  stack_trace TEXT,
+  failure_type TEXT,
+  module_name TEXT,
+  page_name TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (test_run_id) REFERENCES test_runs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_test_results_test_run_id ON test_results(test_run_id);
+CREATE INDEX IF NOT EXISTS idx_test_results_stable_test_key ON test_results(stable_test_key);
+CREATE INDEX IF NOT EXISTS idx_test_results_status ON test_results(status);
+CREATE INDEX IF NOT EXISTS idx_test_results_project_name ON test_results(project_name);
+
+CREATE TABLE IF NOT EXISTS test_artifacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  test_result_id INTEGER NOT NULL,
+  artifact_type TEXT NOT NULL,
+  artifact_path TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (test_result_id) REFERENCES test_results(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_test_artifacts_test_result_id ON test_artifacts(test_result_id);
+CREATE INDEX IF NOT EXISTS idx_test_artifacts_artifact_type ON test_artifacts(artifact_type);
+
+CREATE TABLE IF NOT EXISTS linked_issues (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  test_result_id INTEGER NOT NULL,
+  issue_key TEXT NOT NULL,
+  issue_url TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (test_result_id) REFERENCES test_results(id) ON DELETE CASCADE
+);
+`;

--- a/src/reporting/queries/dashboardQueries.ts
+++ b/src/reporting/queries/dashboardQueries.ts
@@ -1,0 +1,116 @@
+import { DatabaseSync } from "node:sqlite";
+
+export type RunOverview = {
+  run_uuid: string;
+  started_at: string;
+  status: string;
+  total_tests: number;
+  passed_count: number;
+  failed_count: number;
+  skipped_count: number;
+  duration_ms: number;
+  branch: string | null;
+  commit_sha: string | null;
+};
+
+export function withResultsDb<T>(dbPath: string, fn: (db: DatabaseSync) => T): T {
+  const db = new DatabaseSync(dbPath, { open: true, readOnly: true });
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+export function getRecentRuns(dbPath: string, limit = 20): RunOverview[] {
+  return withResultsDb(dbPath, (db) => {
+    const stmt = db.prepare(`
+      SELECT run_uuid, started_at, status, total_tests, passed_count, failed_count,
+             skipped_count, duration_ms, branch, commit_sha
+      FROM test_runs
+      ORDER BY datetime(started_at) DESC
+      LIMIT ?
+    `);
+
+    return stmt.all(limit) as RunOverview[];
+  });
+}
+
+export function getFailureRateByTest(dbPath: string, limit = 50) {
+  return withResultsDb(dbPath, (db) => {
+    const stmt = db.prepare(`
+      SELECT
+        stable_test_key,
+        MAX(test_title) AS test_title,
+        COUNT(*) AS total_executions,
+        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count,
+        ROUND(100.0 * SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) / COUNT(*), 2) AS failure_rate_pct
+      FROM test_results
+      GROUP BY stable_test_key
+      HAVING COUNT(*) >= 1
+      ORDER BY failure_rate_pct DESC, total_executions DESC
+      LIMIT ?
+    `);
+
+    return stmt.all(limit);
+  });
+}
+
+export function getFlakyCandidates(dbPath: string, minRuns = 5, limit = 25) {
+  return withResultsDb(dbPath, (db) => {
+    const stmt = db.prepare(`
+      SELECT
+        stable_test_key,
+        MAX(test_title) AS test_title,
+        COUNT(*) AS total_runs,
+        SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) AS pass_count,
+        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS fail_count
+      FROM test_results
+      GROUP BY stable_test_key
+      HAVING COUNT(*) >= ?
+         AND SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) > 0
+         AND SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) > 0
+      ORDER BY total_runs DESC, fail_count DESC
+      LIMIT ?
+    `);
+
+    return stmt.all(minRuns, limit);
+  });
+}
+
+export function getSlowestTests(dbPath: string, limit = 25) {
+  return withResultsDb(dbPath, (db) => {
+    const stmt = db.prepare(`
+      SELECT
+        stable_test_key,
+        MAX(test_title) AS test_title,
+        ROUND(AVG(duration_ms), 2) AS avg_duration_ms,
+        MAX(duration_ms) AS max_duration_ms,
+        COUNT(*) AS total_runs
+      FROM test_results
+      WHERE duration_ms IS NOT NULL
+      GROUP BY stable_test_key
+      ORDER BY avg_duration_ms DESC
+      LIMIT ?
+    `);
+
+    return stmt.all(limit);
+  });
+}
+
+export function getFailuresByModule(dbPath: string, limit = 20) {
+  return withResultsDb(dbPath, (db) => {
+    const stmt = db.prepare(`
+      SELECT
+        COALESCE(module_name, 'unknown') AS module_name,
+        COUNT(*) AS total_failures
+      FROM test_results
+      WHERE status = 'failed'
+      GROUP BY COALESCE(module_name, 'unknown')
+      ORDER BY total_failures DESC
+      LIMIT ?
+    `);
+
+    return stmt.all(limit);
+  });
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -21,8 +21,19 @@ function getEnv(name: string, fallback?: string): string {
   return val;
 }
 
+function getEnvBool(name: string, fallback: boolean): boolean {
+  const val = process.env[name];
+  if (val === undefined) {
+    return fallback;
+  }
+
+  return val.toLowerCase() === "true";
+}
+
 export const env = {
   BASE_URL: getEnv("BASE_URL", "https://playground.testduo.co.za"),
   E2E_EMAIL: process.env.E2E_EMAIL ?? "",
-  E2E_PASSWORD: process.env.E2E_PASSWORD ?? ""
+  E2E_PASSWORD: process.env.E2E_PASSWORD ?? "",
+  RESULTS_DB_ENABLED: getEnvBool("RESULTS_DB_ENABLED", false),
+  RESULTS_DB_PATH: getEnv("RESULTS_DB_PATH", "./artifacts/results.db")
 };


### PR DESCRIPTION
### Motivation

- Persist Playwright run and test outcomes to a local DB to enable reporting, trend analysis, flaky-test detection, and future prediction/risk scoring.
- Provide a simple DB-first schema and small access layer that can be swapped for PostgreSQL later with minimal changes.
- Keep the feature optional and non-breaking so existing workflows remain unchanged unless explicitly enabled.

### Description

- Added a custom Playwright reporter `src/reporting/ResultsDbReporter.ts` that writes one `test_runs` row on `onBegin`, collects per-test results during the run, and writes `test_results` + `test_artifacts` on `onEnd` (captures `error_message` and `stack_trace` where available).
- Implemented a lightweight DB access layer `src/reporting/db/resultsDb.ts` and schema `src/reporting/db/schema.ts` that initialize an SQLite DB, create tables/indexes (`test_runs`, `test_results`, `test_artifacts`, `linked_issues`) and expose insert/update methods with a transaction around test-result + artifact writes.
- Added starter analytics queries in `src/reporting/queries/dashboardQueries.ts` (recent runs, failure rate by test, flaky candidates, slowest tests, failures by module) as a small query helper module for future dashboards.
- Made the reporter optional and configurable via environment variables and runtime config: `RESULTS_DB_ENABLED` and `RESULTS_DB_PATH`; wired into `playwright.config.ts` without removing existing reporters; added env helpers in `src/utils/env.ts` and documented the feature in `readme.md` and `.env.example`.

### Testing

- `npm run lint` (`tsc --noEmit`) succeeded after type adjustments to the reporter. (`npm run lint` ✔️)
- Executed a Playwright run with the reporter enabled: `RESULTS_DB_ENABLED=true RESULTS_DB_PATH=./artifacts/results.db npx playwright test tests/login.public.spec.ts --project=chromium-public`, the run failed due to missing Playwright browser binaries in this environment (not related to reporter code), but the reporter initialized and persisted rows before test failures. (Playwright run — reporter initialization OK, test execution failed due to environment).
- Verified DB contents using Node/`node:sqlite` queries against `./artifacts/results.db` and confirmed rows were created (example observed: `test_runs: 1`, `test_results: 2`, `test_artifacts: 0`) and failure details were stored as expected. (DB verification ✔️)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc825fa08c8321b1226c71b8f21842)